### PR TITLE
Update Create-Win32App.ps1

### DIFF
--- a/scripts/Create-Win32App.ps1
+++ b/scripts/Create-Win32App.ps1
@@ -47,7 +47,7 @@ process {
     $AppData = Get-Content -Path $Json | ConvertFrom-Json
 
     # Required packaging variables
-    $ScriptsFolder = [System.IO.Path]::Combine($PSScriptRoot, "Scripts")
+    $ScriptsFolder = $PSScriptRoot
 
     # Icon file - download the file, if the property is a URL
     if ($AppData.PackageInformation.IconFile -match "^http") {
@@ -206,7 +206,7 @@ process {
                             # Create a custom script based requirement rule
                             $RequirementRuleArgs = @{
                                 "IntegerOutputDataType"     = $true
-                                "ScriptFile"                = $RequirementRuleItem.ScriptFile
+                                "ScriptFile"                = (Join-Path -Path $ScriptsFolder -ChildPath $RequirementRuleItem.ScriptFile)
                                 "ScriptContext"             = $RequirementRuleItem.ScriptContext
                                 "IntegerComparisonOperator" = $RequirementRuleItem.Operator
                                 "IntegerValue"              = $RequirementRuleItem.Value
@@ -218,7 +218,7 @@ process {
                             # Create a custom script based requirement rule
                             $RequirementRuleArgs = @{
                                 "BooleanOutputDataType"     = $true
-                                "ScriptFile"                = $RequirementRuleItem.ScriptFile
+                                "ScriptFile"                = (Join-Path -Path $ScriptsFolder -ChildPath $RequirementRuleItem.ScriptFile)
                                 "ScriptContext"             = $RequirementRuleItem.ScriptContext
                                 "BooleanComparisonOperator" = $RequirementRuleItem.Operator
                                 "BooleanValue"              = $RequirementRuleItem.Value
@@ -230,7 +230,7 @@ process {
                             # Create a custom script based requirement rule
                             $RequirementRuleArgs = @{
                                 "DateTimeOutputDataType"     = $true
-                                "ScriptFile"                 = $RequirementRuleItem.ScriptFile
+                                "ScriptFile"                 = (Join-Path -Path $ScriptsFolder -ChildPath $RequirementRuleItem.ScriptFile)
                                 "ScriptContext"              = $RequirementRuleItem.ScriptContext
                                 "DateTimeComparisonOperator" = $RequirementRuleItem.Operator
                                 "DateTimeValue"              = $RequirementRuleItem.Value
@@ -242,7 +242,7 @@ process {
                             # Create a custom script based requirement rule
                             $RequirementRuleArgs = @{
                                 "FloatOutputDataType"     = $true
-                                "ScriptFile"              = $RequirementRuleItem.ScriptFile
+                                "ScriptFile"              = (Join-Path -Path $ScriptsFolder -ChildPath $RequirementRuleItem.ScriptFile)
                                 "ScriptContext"           = $RequirementRuleItem.ScriptContext
                                 "FloatComparisonOperator" = $RequirementRuleItem.Operator
                                 "FloatValue"              = $RequirementRuleItem.Value
@@ -254,7 +254,7 @@ process {
                             # Create a custom script based requirement rule
                             $RequirementRuleArgs = @{
                                 "VersionOutputDataType"     = $true
-                                "ScriptFile"                = $RequirementRuleItem.ScriptFile
+                                "ScriptFile"                = (Join-Path -Path $ScriptsFolder -ChildPath $RequirementRuleItem.ScriptFile)
                                 "ScriptContext"             = $RequirementRuleItem.ScriptContext
                                 "VersionComparisonOperator" = $RequirementRuleItem.Operator
                                 "VersionValue"              = $RequirementRuleItem.Value


### PR DESCRIPTION
Because Create-Win32App.ps1 is located in the scripts folder, the $ScriptsFolder variable would always end up with a path of .\scripts\Scripts\*.ps1. Change to $ScriptsFolder = $PSScriptRoot Instead to resolve issue.
In addition Updated all "ScriptFile" to use consistent full path otherwise the functions are unable to find the file.